### PR TITLE
Fix pnpm install build approvals

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,11 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.3"
   },
-  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
+  "packageManager": "pnpm@10.14.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "unrs-resolver"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
Pin pnpm to `10.14.0`, which is compatible with the repository’s Node runtime, and explicitly allow the native install scripts required by `sharp` and `unrs-resolver`. This prevents `ERR_PNPM_IGNORED_BUILDS` from failing unattended installs.

Verified with:
- `pnpm install --frozen-lockfile`
- `pnpm exec next lint`
- `pnpm exec tsc --noEmit`
- `pnpm run build` with placeholder Supabase environment values

Link to Devin session: https://app.devin.ai/sessions/8bab2fae5c044b059802f72b9904fddf
Requested by: @kierro1209