### PR TITLE
fix: validate member profile image URLs

### DIFF
--- a/src/app/(home)/members/edit/[slug]/page.tsx
+++ b/src/app/(home)/members/edit/[slug]/page.tsx
@@ -177,9 +177,15 @@ export default function EditProfilePage({ params }: Params) {
 
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Upload failed");
+      if (
+        typeof data.url !== "string" ||
+        (!data.url.startsWith("https://") && !data.url.startsWith("http://"))
+      ) {
+        throw new Error("Upload service returned an invalid image URL");
+      }
 
       URL.revokeObjectURL(previewUrl);
-      setImageSrc(data.url as string);
+      setImageSrc(data.url);
       toast.success("Photo uploaded");
     } catch (err) {
       console.error("Upload error:", err);

--- a/src/app/api/members/update/route.ts
+++ b/src/app/api/members/update/route.ts
@@ -120,8 +120,15 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    if ("imageSrc" in updateData && typeof updateData.imageSrc !== "string") {
+      return NextResponse.json(
+        { error: "imageSrc must be a URL string (upload the image first)" },
+        { status: 400 }
+      );
+    }
+
     if (typeof updateData.imageSrc === "string" && updateData.imageSrc.length > 0) {
-      const src = updateData.imageSrc as string;
+      const src = updateData.imageSrc;
       if (!src.startsWith("https://") && !src.startsWith("http://")) {
         return NextResponse.json(
           {

--- a/src/lib/orm/mappers.ts
+++ b/src/lib/orm/mappers.ts
@@ -54,7 +54,7 @@ export function toMemberDoc(
     classYear: data.classYear as string | undefined,
     joinedYear: data.joinedYear as string | undefined,
     joinedQuarter: parseJoinedQuarter(data.joinedQuarter),
-    imageSrc: data.imageSrc as string | undefined,
+    imageSrc: typeof data.imageSrc === "string" ? data.imageSrc : undefined,
     bio: data.bio as string | undefined,
     interests: (data.interests as string[]) ?? [],
     experiences: (data.experiences as Experience[]) ?? [],


### PR DESCRIPTION
## Summary
Member profile image uploads now persist only validated HTTP(S) URL strings.

- `handleImageUpload` rejects malformed upload responses before updating profile state.
- `/api/members/update` rejects non-string `imageSrc` values before any Firestore write.
- `toMemberDoc` ignores malformed historical `imageSrc` values instead of exposing them as strings.

This prevents `File`, `Blob`, object, or object-like image data from reaching Firestore, where it causes invalid JSON/value errors.

Link to Devin session: https://app.devin.ai/sessions/8bab2fae5c044b059802f72b9904fddf
Requested by: @kierro1209