### PR TITLE
fix: deploy Next.js API routes on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
The reported production URL returns the same generic HTML 500 for `/api/members/update`, `/api/upload/image`, and `/api/admin/create-member` even without authentication. Local Next.js returns the expected JSON 401, proving the handlers are not being reached in that Vercel deployment; this is a deployment packaging/configuration issue, not Cloudinary.

`vercel.json` explicitly configures the project as Next.js, uses the pnpm frozen-lockfile install and Next build, and sets `.next` as the output directory so App Router API routes are deployed as server functions instead of falling through to the static 500 page.

Link to Devin session: https://app.devin.ai/sessions/8bab2fae5c044b059802f72b9904fddf
Requested by: @kierro1209