### PR TITLE
fix: let Vercel deploy Next.js API functions

### DIFF
--- a/src/app/api/members/update/route.ts
+++ b/src/app/api/members/update/route.ts
@@ -48,12 +48,13 @@ export async function POST(req: NextRequest) {
     }
     console.log("[update] User verified:", userInfo.email);
 
-    const body = await req.json();
-    if (!body || typeof body !== "object") {
+    const body: unknown = await req.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
       return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
     }
-    console.log("[update] Payload received for:", body.targetEmail);
-    const { targetEmail, ...profileData } = body;
+    const payload = body as Record<string, unknown>;
+    console.log("[update] Payload received for:", payload.targetEmail);
+    const { targetEmail, ...profileData } = payload;
 
     if (!targetEmail || typeof targetEmail !== "string") {
       return NextResponse.json({ error: "Missing targetEmail" }, { status: 400 });
@@ -102,6 +103,82 @@ export async function POST(req: NextRequest) {
       if (field in profileData) {
         updateData[field] = profileData[field];
       }
+    }
+
+    const stringFields = [
+      "firstName",
+      "lastName",
+      "bio",
+      "currentlyWorkingOn",
+      "major",
+      "classYear",
+      "city",
+      "linkedin",
+      "twitter",
+      "github",
+      "website",
+      "phone",
+      "joinedYear",
+    ] as const;
+    for (const field of stringFields) {
+      if (field in updateData && updateData[field] !== undefined &&
+          typeof updateData[field] !== "string") {
+        return NextResponse.json(
+          { error: `${field} must be a string` },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (
+      "interests" in updateData &&
+      (!Array.isArray(updateData.interests) ||
+        !updateData.interests.every((item) => typeof item === "string"))
+    ) {
+      return NextResponse.json(
+        { error: "interests must be an array of strings" },
+        { status: 400 }
+      );
+    }
+
+    if ("experiences" in updateData) {
+      const experiences = updateData.experiences;
+      const validExperiences =
+        Array.isArray(experiences) &&
+        experiences.every((experience) => {
+          if (
+            !experience ||
+            typeof experience !== "object" ||
+            Array.isArray(experience)
+          ) {
+            return false;
+          }
+          const item = experience as Record<string, unknown>;
+          return (
+            typeof item.company === "string" &&
+            typeof item.role === "string" &&
+            (item.startDate === undefined || typeof item.startDate === "string") &&
+            (item.endDate === undefined || typeof item.endDate === "string") &&
+            (item.description === undefined ||
+              typeof item.description === "string")
+          );
+        });
+      if (!validExperiences) {
+        return NextResponse.json(
+          { error: "experiences contains an invalid entry" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (
+      "profileCompleted" in updateData &&
+      typeof updateData.profileCompleted !== "boolean"
+    ) {
+      return NextResponse.json(
+        { error: "profileCompleted must be a boolean" },
+        { status: 400 }
+      );
     }
 
     if (typeof updateData.vestTitle === "string" && updateData.vestTitle.length > 0) {

--- a/src/lib/orm/mappers.ts
+++ b/src/lib/orm/mappers.ts
@@ -37,34 +37,68 @@ function parseStatus(value: unknown): MemberStatus {
   return value === MemberStatus.Alumni ? MemberStatus.Alumni : MemberStatus.Active;
 }
 
+function parseString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function parseExperiences(value: unknown): Experience[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    const experience = item as Record<string, unknown>;
+    if (
+      typeof experience.company !== "string" ||
+      typeof experience.role !== "string"
+    ) {
+      return [];
+    }
+    return [{
+      company: experience.company,
+      role: experience.role,
+      startDate: parseString(experience.startDate),
+      endDate: parseString(experience.endDate),
+      description: parseString(experience.description),
+    }];
+  });
+}
+
 export function toMemberDoc(
   uuid: string,
   data: Record<string, unknown>
 ): MemberDoc {
   return {
     uuid,
-    email: (data.email as string) ?? "",
-    firstName: data.firstName as string | undefined,
-    lastName: data.lastName as string | undefined,
+    email: parseString(data.email) ?? "",
+    firstName: parseString(data.firstName),
+    lastName: parseString(data.lastName),
     role: data.role ? parseRole(data.role) : undefined,
     status: data.status ? parseStatus(data.status) : undefined,
-    profileCompleted: data.profileCompleted as boolean | undefined,
-    createdAt: data.createdAt as string | undefined,
+    profileCompleted:
+      typeof data.profileCompleted === "boolean"
+        ? data.profileCompleted
+        : undefined,
+    createdAt: parseString(data.createdAt),
     vestTitle: parseVestTitle(data.vestTitle),
-    classYear: data.classYear as string | undefined,
-    joinedYear: data.joinedYear as string | undefined,
+    classYear: parseString(data.classYear),
+    joinedYear: parseString(data.joinedYear),
     joinedQuarter: parseJoinedQuarter(data.joinedQuarter),
     imageSrc: typeof data.imageSrc === "string" ? data.imageSrc : undefined,
-    bio: data.bio as string | undefined,
-    interests: (data.interests as string[]) ?? [],
-    experiences: (data.experiences as Experience[]) ?? [],
-    currentlyWorkingOn: data.currentlyWorkingOn as string | undefined,
-    major: data.major as string | undefined,
-    city: data.city as string | undefined,
-    linkedin: data.linkedin as string | undefined,
-    twitter: data.twitter as string | undefined,
-    github: data.github as string | undefined,
-    website: data.website as string | undefined,
+    bio: parseString(data.bio),
+    interests: parseStringArray(data.interests),
+    experiences: parseExperiences(data.experiences),
+    currentlyWorkingOn: parseString(data.currentlyWorkingOn),
+    major: parseString(data.major),
+    city: parseString(data.city),
+    linkedin: parseString(data.linkedin),
+    twitter: parseString(data.twitter),
+    github: parseString(data.github),
+    website: parseString(data.website),
   };
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm run build",
-  "outputDirectory": ".next"
+  "buildCommand": "pnpm run build"
 }


### PR DESCRIPTION
## Summary
Vercel was serving the generated Next.js static 500 page for `/api/*` instead of invoking App Router route handlers. Remove the `.next` output-directory override so Vercel's native Next.js builder can emit API functions, while retaining the frozen pnpm install and build command.

The same PR also hardens the profile update boundary:
- rejects non-object JSON payloads;
- validates text and boolean fields;
- requires string arrays for `interests`;
- validates the shape of `experiences` entries;
- safely filters malformed historical Firestore values during mapping.

This prevents Firestore/UI type mismatches when profile data contains mixed text, arrays, or legacy malformed values.

Link to Devin session: https://app.devin.ai/sessions/8bab2fae5c044b059802f72b9904fddf
Requested by: @kierro1209